### PR TITLE
Place ships individually and randomly in debug mode

### DIFF
--- a/js/battleboat.js
+++ b/js/battleboat.js
@@ -715,7 +715,7 @@ Fleet.prototype.placeShipsRandomly = function() {
 				continue;
 			}
 		}
-		if (this.player === CONST.HUMAN_PLAYER && usedShips != 1) {
+		if (this.player === CONST.HUMAN_PLAYER && usedShips[i] != 1) {
 			for (var j = 0; j < shipCoords.length; j++) {
 				this.playerGrid.updateCell(shipCoords[j].x, shipCoords[j].y, 'ship', this.player);
 				usedShips[i] = 1;


### PR DESCRIPTION
This is a quick fix that allows the user to select ships to place, and
then place the rest of this ships randomly in debug mode. Before when
the ships were placed randomly it would not account for ships that were
already placed by the user.

I added an array that keeps track of which ships have been placed by
changing the value from 0 to 1.

Perhaps there is a better way, but since the whole program seems to be based upon the coordinates more than the ships, it seemed to me the best way was to simply track the ships.

In response to: https://github.com/Kortaggio/battleboat/issues/4
